### PR TITLE
Improve compatibility with older GE plugins

### DIFF
--- a/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/BuildCacheConfigurationAdapter.java
+++ b/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/BuildCacheConfigurationAdapter.java
@@ -1,0 +1,81 @@
+package com.gradle.develocity.agent.gradle.adapters;
+
+
+import javax.annotation.Nullable;
+
+public interface BuildCacheConfigurationAdapter {
+
+    LocalBuildCacheAdapter getLocal();
+
+    @Nullable
+    RemoteBuildCacheAdapter getRemote();
+
+    /**
+     *  @see org.gradle.caching.local.DirectoryBuildCache
+     */
+    interface LocalBuildCacheAdapter {
+        boolean isEnabled();
+
+        void setEnabled(boolean enabled);
+
+        boolean isPush();
+
+        void setPush(boolean storeEnabled);
+
+        String getDirectory();
+
+        void setDirectory(String directory);
+
+        int getRemoveUnusedEntriesAfterDays();
+
+        void setRemoveUnusedEntriesAfterDays(int days);
+    }
+
+    /**
+     *  @see org.gradle.caching.http.HttpBuildCache
+     *  @see com.gradle.develocity.agent.gradle.buildcache.DevelocityBuildCache
+     *  @see com.gradle.enterprise.gradleplugin.GradleEnterpriseBuildCache
+     */
+    interface RemoteBuildCacheAdapter {
+        boolean isEnabled();
+
+        void setEnabled(boolean enabled);
+
+        boolean isPush();
+
+        void setPush(boolean storeEnabled);
+
+        @Nullable
+        String getUrl();
+
+        void setUrl(@Nullable String url);
+
+        @Nullable
+        String getServer();
+
+        void setServer(@Nullable String server);
+
+        @Nullable
+        String getPath();
+
+        void setPath(@Nullable String path);
+
+        boolean getAllowUntrustedServer();
+
+        void setAllowUntrustedServer(boolean allowUntrusted);
+
+        boolean getAllowInsecureProtocol();
+
+        void setAllowInsecureProtocol(boolean allowInsecureProtocol);
+
+        boolean getUseExpectContinue();
+
+        void setUseExpectContinue(boolean useExpectContinue);
+
+        @Nullable
+        Object getUsernameAndPassword();
+
+        void usernameAndPassword(String username, String password);
+    }
+
+}

--- a/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/internal/AdapterTypeUtils.java
+++ b/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/internal/AdapterTypeUtils.java
@@ -32,13 +32,7 @@ public class AdapterTypeUtils {
     private static boolean implementsInterface(Object object, String interfaceName) {
         Class<?> clazz = object.getClass();
         while (clazz != null) {
-            Class<?>[] interfaces = clazz.getInterfaces();
-            boolean implementsInterface = Stream.concat(
-                Arrays.stream(interfaces),
-                Arrays.stream(interfaces).flatMap(it -> Arrays.stream(it.getInterfaces()))
-            ).anyMatch(it -> interfaceName.equals(it.getName()));
-
-            if (implementsInterface) {
+            if (implementsInterface(clazz, interfaceName)) {
                 return true;
             }
 
@@ -46,5 +40,13 @@ public class AdapterTypeUtils {
         }
 
         return false;
+    }
+
+    private static boolean implementsInterface(Class<?> clazz, String interfaceName) {
+        if (interfaceName.equals(clazz.getName())) {
+            return true;
+        }
+
+        return Arrays.stream(clazz.getInterfaces()).anyMatch(it -> implementsInterface(it, interfaceName));
     }
 }

--- a/develocity-gradle-plugin-adapters/src/develocityCompatibility/java/com/gradle/develocity/agent/gradle/adapters/develocity/GradleBuildCacheConfigurationAdapter.java
+++ b/develocity-gradle-plugin-adapters/src/develocityCompatibility/java/com/gradle/develocity/agent/gradle/adapters/develocity/GradleBuildCacheConfigurationAdapter.java
@@ -1,0 +1,349 @@
+package com.gradle.develocity.agent.gradle.adapters.develocity;
+
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
+
+import org.gradle.caching.configuration.BuildCache;
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.gradle.caching.http.HttpBuildCache;
+import org.gradle.caching.local.DirectoryBuildCache;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+/**
+ * Provides a common adapter layer for any `BuildCacheConfiguration` instance supplied by Gradle.
+ * Several different remote build cache implementations are adapted:
+ * - org.gradle.caching.http.HttpBuildCache
+ * - com.gradle.develocity.agent.gradle.buildcache.DevelocityBuildCache
+ * - com.gradle.enterprise.gradleplugin.GradleEnterpriseBuildCache
+ */
+public class GradleBuildCacheConfigurationAdapter implements BuildCacheConfigurationAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(GradleBuildCacheConfigurationAdapter.class);
+
+    private final BuildCacheConfiguration buildCache;
+
+    public GradleBuildCacheConfigurationAdapter(BuildCacheConfiguration buildCache) {
+        this.buildCache = buildCache;
+    }
+
+    @Override
+    public LocalBuildCacheAdapter getLocal() {
+        return new LocalBuildCache(buildCache.getLocal());
+    }
+
+    @Override
+    public @Nullable RemoteBuildCacheAdapter getRemote() {
+        BuildCache remoteConfig = buildCache.getRemote();
+        if (remoteConfig == null) {
+            return null;
+        } else if (remoteConfig instanceof HttpBuildCache) {
+            return new HttpRemoteBuildCache((HttpBuildCache) remoteConfig);
+        } else {
+            return new ReflectingRemoteBuildCache(remoteConfig);
+        }
+    }
+
+    private static class LocalBuildCache implements LocalBuildCacheAdapter {
+        private final DirectoryBuildCache localBuildCache;
+
+        private LocalBuildCache(DirectoryBuildCache localBuildCache) {
+            this.localBuildCache = localBuildCache;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return localBuildCache.isEnabled();
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            localBuildCache.setEnabled(enabled);
+        }
+
+        @Override
+        public boolean isPush() {
+            return localBuildCache.isPush();
+        }
+
+        @Override
+        public void setPush(boolean push) {
+            localBuildCache.setPush(push);
+        }
+
+        @Override
+        public String getDirectory() {
+            return String.valueOf(localBuildCache.getDirectory());
+        }
+
+        @Override
+        public void setDirectory(String directory) {
+            localBuildCache.setDirectory(directory);
+        }
+
+        @Override
+        public int getRemoveUnusedEntriesAfterDays() {
+            return localBuildCache.getRemoveUnusedEntriesAfterDays();
+        }
+
+        @Override
+        public void setRemoveUnusedEntriesAfterDays(int days) {
+            localBuildCache.setRemoveUnusedEntriesAfterDays(days);
+        }
+    }
+
+    private static class HttpRemoteBuildCache implements RemoteBuildCacheAdapter {
+        private final HttpBuildCache remoteBuildCache;
+
+        private HttpRemoteBuildCache(HttpBuildCache remoteBuildCache) {
+            this.remoteBuildCache = remoteBuildCache;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return remoteBuildCache.isEnabled();
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            remoteBuildCache.setEnabled(enabled);
+        }
+
+        @Override
+        public boolean isPush() {
+            return remoteBuildCache.isPush();
+        }
+
+        @Override
+        public void setPush(boolean push) {
+            remoteBuildCache.setPush(push);
+        }
+
+        @Override
+        public @Nullable String getUrl() {
+            URI url = remoteBuildCache.getUrl();
+            return url == null ? null : url.toASCIIString();
+        }
+
+        @Override
+        public void setUrl(String url) {
+            remoteBuildCache.setUrl(url);
+        }
+
+        @Override
+        public @Nullable String getServer() {
+            warnAboutUnsupportedMethod("getServer");
+            return null;
+        }
+
+        @Override
+        public void setServer(@Nullable String server) {
+            warnAboutUnsupportedMethod("setServer");
+        }
+
+        @Override
+        public @Nullable String getPath() {
+            warnAboutUnsupportedMethod("getPath");
+            return null;
+        }
+
+        @Override
+        public void setPath(@Nullable String path) {
+            warnAboutUnsupportedMethod("setPath");
+        }
+
+        @Override
+        public boolean getAllowUntrustedServer() {
+            return remoteBuildCache.isAllowUntrustedServer();
+        }
+
+        @Override
+        public void setAllowUntrustedServer(boolean allowUntrusted) {
+            remoteBuildCache.setAllowUntrustedServer(allowUntrusted);
+        }
+
+        @Override
+        public boolean getAllowInsecureProtocol() {
+            return remoteBuildCache.isAllowInsecureProtocol();
+        }
+
+        @Override
+        public void setAllowInsecureProtocol(boolean allowInsecureProtocol) {
+            remoteBuildCache.setAllowInsecureProtocol(allowInsecureProtocol);
+        }
+
+        @Override
+        public boolean getUseExpectContinue() {
+            warnAboutUnsupportedMethod("getUseExpectContinue");
+            return false;
+        }
+
+        @Override
+        public void setUseExpectContinue(boolean useExpectContinue) {
+            warnAboutUnsupportedMethod("setUseExpectContinue");
+        }
+
+        @Override
+        public @Nullable Object getUsernameAndPassword() {
+            warnAboutUnsupportedMethod("getUsernameAndPassword");
+            return null;
+        }
+
+        @Override
+        public void usernameAndPassword(String username, String password) {
+            warnAboutUnsupportedMethod("usernameAndPassword");
+        }
+    }
+
+    private static class ReflectingRemoteBuildCache implements RemoteBuildCacheAdapter {
+        private final BuildCache remoteBuildCache;
+
+        private ReflectingRemoteBuildCache(BuildCache remoteBuildCache) {
+            this.remoteBuildCache = remoteBuildCache;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return remoteBuildCache.isEnabled();
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            remoteBuildCache.setEnabled(enabled);
+        }
+
+        @Override
+        public boolean isPush() {
+            return remoteBuildCache.isPush();
+        }
+
+        @Override
+        public void setPush(boolean push) {
+            remoteBuildCache.setPush(push);
+        }
+
+        @Override
+        public @Nullable String getUrl() {
+            warnAboutUnsupportedMethod("getUrl");
+            return null;
+        }
+
+        @Override
+        public void setUrl(@Nullable String url) {
+            warnAboutUnsupportedMethod("setUrl");
+        }
+
+        @Override
+        public @Nullable String getServer() {
+            return getStringProperty("getServer");
+        }
+
+        @Override
+        public void setServer(@Nullable String server) {
+            setStringProperty("setServer", server);
+        }
+
+        @Override
+        public @Nullable String getPath() {
+            return getStringProperty("getPath");
+        }
+
+        @Override
+        public void setPath(@Nullable String path) {
+            setStringProperty("setPath", path);
+        }
+
+        @Override
+        public boolean getAllowUntrustedServer() {
+            return getBooleanProperty("getAllowUntrustedServer");
+        }
+
+        @Override
+        public void setAllowUntrustedServer(boolean allowUntrusted) {
+            setBooleanProperty("setAllowUntrustedServer", allowUntrusted);
+        }
+
+        @Override
+        public boolean getAllowInsecureProtocol() {
+            return getBooleanProperty("getAllowInsecureProtocol");
+        }
+
+        @Override
+        public void setAllowInsecureProtocol(boolean allowInsecureProtocol) {
+            setBooleanProperty("setAllowInsecureProtocol", allowInsecureProtocol);
+        }
+
+        @Override
+        public boolean getUseExpectContinue() {
+            return getBooleanProperty("getUseExpectContinue");
+        }
+
+        @Override
+        public void setUseExpectContinue(boolean useExpectContinue) {
+            setBooleanProperty("setUseExpectContinue", useExpectContinue);
+        }
+
+        @Override
+        public @Nullable Object getUsernameAndPassword() {
+            return getProperty("getUsernameAndPassword");
+        }
+
+        @Override
+        public void usernameAndPassword(String username, String password) {
+            try {
+                Method setter = remoteBuildCache.getClass().getDeclaredMethod("usernameAndPassword", String.class, String.class);
+                setter.invoke(remoteBuildCache, username, password);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                warnAboutUnsupportedMethod("usernameAndPassword");
+            }
+        }
+
+        private Object getProperty(String name) {
+            try {
+                Method getter = remoteBuildCache.getClass().getDeclaredMethod(name);
+                return getter.invoke(remoteBuildCache);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                warnAboutUnsupportedMethod(name);
+                return null;
+            }
+        }
+
+        private <T> void setProperty(String name, Class<T> type, T value) {
+            try {
+                Method setter = remoteBuildCache.getClass().getDeclaredMethod(name, type);
+                setter.invoke(remoteBuildCache, value);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchMethodException e) {
+                warnAboutUnsupportedMethod(name);
+            }
+        }
+
+        private String getStringProperty(String name) {
+            return (String) getProperty(name);
+        }
+
+        private void setStringProperty(String name, String value) {
+            setProperty(name, String.class, value);
+        }
+
+        private boolean getBooleanProperty(String name) {
+            return Boolean.TRUE.equals(getProperty(name));
+        }
+
+        private void setBooleanProperty(String name, boolean value) {
+            setProperty(name, Boolean.TYPE, value);
+        }
+    }
+
+    private static void warnAboutUnsupportedMethod(String name) {
+        LOG.warn("Remote Build Cache instance does not support the {} method", name);
+    }
+}

--- a/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/DevelocityBuildCacheConfigurationAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/DevelocityBuildCacheConfigurationAdapterTest.java
@@ -1,0 +1,165 @@
+package com.gradle.develocity.agent.gradle.adapters.develocity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
+import com.gradle.develocity.agent.gradle.buildcache.DevelocityBuildCache;
+
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DevelocityBuildCacheConfigurationAdapterTest {
+
+    private DevelocityBuildCache cache;
+    private BuildCacheConfigurationAdapter.RemoteBuildCacheAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        cache = mock();
+        BuildCacheConfiguration configuration = mock(BuildCacheConfiguration.class);
+        when(configuration.getRemote()).thenReturn(cache);
+
+        adapter = new GradleBuildCacheConfigurationAdapter(configuration).getRemote();
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the server value using adapter")
+    void testServer() {
+        //given
+        String server = "https://ge-server.com";
+
+        // when
+        adapter.setServer(server);
+
+        // then
+        verify(cache).setServer(server);
+
+        // when
+        when(cache.getServer()).thenReturn(server);
+
+        // then
+        assertEquals(server, adapter.getServer());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the cache path using adapter")
+    void testPath() {
+        //given
+        String path = "path";
+
+        // when
+        adapter.setPath(path);
+
+        // then
+        verify(cache).setPath(path);
+
+        // when
+        when(cache.getPath()).thenReturn(path);
+
+        // then
+        assertEquals(path, adapter.getPath());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowUntrustedServer value using adapter")
+    void testAllowUntrustedServer() {
+        // when
+        adapter.setAllowUntrustedServer(true);
+
+        // then
+        verify(cache).setAllowUntrustedServer(true);
+
+        // when
+        when(cache.getAllowUntrustedServer()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowUntrustedServer());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowInsecureProtocol value using adapter")
+    void testAllowInsecureProtocol() {
+        // when
+        adapter.setAllowInsecureProtocol(true);
+
+        // then
+        verify(cache).setAllowInsecureProtocol(true);
+
+        // when
+        when(cache.getAllowInsecureProtocol()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowInsecureProtocol());
+    }
+
+    @Test
+    @DisplayName("can set the username and password value using adapter")
+    void testUsernameAndPassword() {
+        // given
+        String username = "user";
+        String password = "pass";
+
+        // when
+        adapter.usernameAndPassword(username, password);
+
+        // then
+        verify(cache).usernameAndPassword(username, password);
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the useExpectContinue value using adapter")
+    void testUseExpectContinue() {
+        // when
+        adapter.setUseExpectContinue(true);
+
+        // then
+        verify(cache).setUseExpectContinue(true);
+
+        // when
+        when(cache.getUseExpectContinue()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getUseExpectContinue());
+    }
+
+    @Test
+    @DisplayName("can enable using adapter")
+    void testEnable() {
+        // when
+        adapter.setEnabled(true);
+
+        // then
+        verify(cache).setEnabled(true);
+
+        // when
+        when(cache.isEnabled()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isEnabled());
+    }
+
+    @Test
+    @DisplayName("can enable pushing using adapter")
+    void testPush() {
+        // when
+        adapter.setPush(true);
+
+        // then
+        verify(cache).setPush(true);
+
+        // when
+        when(cache.isPush()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isPush());
+    }
+}

--- a/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/HttpBuildCacheConfigurationAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/HttpBuildCacheConfigurationAdapterTest.java
@@ -1,0 +1,120 @@
+package com.gradle.develocity.agent.gradle.adapters.develocity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
+
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.gradle.caching.http.HttpBuildCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HttpBuildCacheConfigurationAdapterTest {
+
+    private HttpBuildCache cache;
+    private BuildCacheConfigurationAdapter.RemoteBuildCacheAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        cache = mock();
+        BuildCacheConfiguration configuration = mock(BuildCacheConfiguration.class);
+        when(configuration.getRemote()).thenReturn(cache);
+
+        adapter = new GradleBuildCacheConfigurationAdapter(configuration).getRemote();
+    }
+
+    @Test
+    @DisplayName("warns and ignores unsupported operations using adapter")
+    void testServer() {
+        //given
+        String server = "https://ge-server.com";
+
+        // when
+        adapter.setServer("server");
+        adapter.setPath("path");
+        adapter.setUseExpectContinue(true);
+
+        // then
+        verifyNoInteractions(cache);
+
+        // then
+        assertNull(adapter.getServer());
+        assertNull(adapter.getPath());
+        assertFalse(adapter.getUseExpectContinue());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowUntrustedServer value using adapter")
+    void testAllowUntrustedServer() {
+        // when
+        adapter.setAllowUntrustedServer(true);
+
+        // then
+        verify(cache).setAllowUntrustedServer(true);
+
+        // when
+        when(cache.isAllowUntrustedServer()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowUntrustedServer());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowInsecureProtocol value using adapter")
+    void testAllowInsecureProtocol() {
+        // when
+        adapter.setAllowInsecureProtocol(true);
+
+        // then
+        verify(cache).setAllowInsecureProtocol(true);
+
+        // when
+        when(cache.isAllowInsecureProtocol()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowInsecureProtocol());
+    }
+
+    @Test
+    @DisplayName("can enable using adapter")
+    void testEnable() {
+        // when
+        adapter.setEnabled(true);
+
+        // then
+        verify(cache).setEnabled(true);
+
+        // when
+        when(cache.isEnabled()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isEnabled());
+    }
+
+    @Test
+    @DisplayName("can enable pushing using adapter")
+    void testPush() {
+        // when
+        adapter.setPush(true);
+
+        // then
+        verify(cache).setPush(true);
+
+        // when
+        when(cache.isPush()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isPush());
+    }
+}

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibility/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanCapturePropertyAdapter.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibility/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanCapturePropertyAdapter.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  * Copyright 2024-2024 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.gradle.develocity.agent.gradle.adapters.enterprise;
+
+import com.gradle.develocity.agent.gradle.adapters.BuildScanCaptureAdapter;
+import com.gradle.scan.plugin.BuildScanExtension;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class BuildScanCapturePropertyAdapter implements BuildScanCaptureAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(BuildScanCapturePropertyAdapter.class);
+
+    private final BuildScanExtension buildScan;
+
+    BuildScanCapturePropertyAdapter(BuildScanExtension buildScan) {
+        this.buildScan = buildScan;
+    }
+
+    @Override
+    public void setFileFingerprints(boolean capture) {
+        this.buildScan.setCaptureTaskInputFiles(capture);
+    }
+
+    @Override
+    public boolean isFileFingerprints() {
+        return this.buildScan.isCaptureTaskInputFiles();
+    }
+
+    @Override
+    public void setBuildLogging(boolean capture) {
+        warnAboutUnsupportedOperation("capture.buildLogging");
+    }
+
+    @Override
+    public boolean isBuildLogging() {
+        warnAboutUnsupportedOperation("capture.buildLogging");
+        return true; // Build logging will always be captured
+    }
+
+    @Override
+    public void setTestLogging(boolean capture) {
+        warnAboutUnsupportedOperation("capture.testLogging");
+    }
+
+    @Override
+    public boolean isTestLogging() {
+        warnAboutUnsupportedOperation("capture.testLogging");
+        return true; // Test logging will always be captured
+    }
+
+    private static void warnAboutUnsupportedOperation(String op) {
+        LOG.warn("Build Scan Extension does not support '" + op + "' operation");
+    }
+}

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibility/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapter.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibility/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapter.java
@@ -24,8 +24,10 @@ import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter;
 import com.gradle.develocity.agent.gradle.adapters.BuildScanCaptureAdapter;
 import com.gradle.develocity.agent.gradle.adapters.BuildScanObfuscationAdapter;
 import com.gradle.develocity.agent.gradle.adapters.PublishedBuildScanAdapter;
+import com.gradle.scan.plugin.BuildScanCaptureSettings;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.Action;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
@@ -35,13 +37,22 @@ import java.util.List;
 class BuildScanExtensionAdapter implements BuildScanAdapter {
 
     private final BuildScanExtension buildScan;
-    private final BuildScanCaptureSettingsAdapter capture;
+    private final BuildScanCaptureAdapter capture;
     private final BuildScanDataObfuscationAdapter obfuscation;
 
     BuildScanExtensionAdapter(BuildScanExtension buildScan) {
         this.buildScan = buildScan;
-        this.capture = new BuildScanCaptureSettingsAdapter(buildScan.getCapture());
+        this.capture = createCapture(buildScan);
         this.obfuscation = new BuildScanDataObfuscationAdapter(buildScan.getObfuscation());
+    }
+
+    private static @NotNull BuildScanCaptureAdapter createCapture(BuildScanExtension buildScan) {
+        try {
+            return new BuildScanCaptureSettingsAdapter(buildScan.getCapture());
+        } catch (NoSuchMethodError e) {
+            // Earlier versions of the BuildScanExtension did not support `getCapture()`
+            return new BuildScanCapturePropertyAdapter(buildScan);
+        }
     }
 
     @Override

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanCapturePropertyAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanCapturePropertyAdapterTest.java
@@ -1,0 +1,58 @@
+package com.gradle.develocity.agent.gradle.adapters.enterprise;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gradle.develocity.agent.gradle.adapters.internal.ProxyFactory;
+import com.gradle.scan.plugin.BuildScanCaptureSettings;
+import com.gradle.scan.plugin.BuildScanExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BuildScanCapturePropertyAdapterTest {
+
+    private BuildScanExtension extension;
+    private BuildScanCapturePropertyAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        extension = mock();
+        adapter = new BuildScanCapturePropertyAdapter(ProxyFactory.createProxy(extension, BuildScanExtension.class));
+    }
+
+    @Test
+    @DisplayName("returns fixed values for build and test logging using adapter")
+    void testLogging() {
+        // setters are ignored (with warning)
+        adapter.setBuildLogging(false);
+        adapter.setTestLogging(false);
+
+        // then
+        assertTrue(adapter.isBuildLogging());
+        assertTrue(adapter.isTestLogging());
+    }
+
+    @Test
+    @DisplayName("can capture task input files value using adapter")
+    void testTaskInputFiles() {
+        // when
+        adapter.setFileFingerprints(true);
+
+        // then
+        verify(extension).setCaptureTaskInputFiles(true);
+
+        // when
+        when(extension.isCaptureTaskInputFiles()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isFileFingerprints());
+    }
+
+}

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapterTest.java
@@ -265,11 +265,13 @@ class BuildScanExtensionAdapterTest {
 
         // when
         adapter.capture(c -> {
+            c.setFileFingerprints(true);
             c.setBuildLogging(true);
             c.setTestLogging(false);
         });
 
         // then
+        verify(capture).setTaskInputFiles(true);
         verify(capture).setBuildLogging(true);
         verify(capture).setTestLogging(false);
     }

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/GradleEnterpriseBuildCacheConfigurationAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/GradleEnterpriseBuildCacheConfigurationAdapterTest.java
@@ -1,0 +1,166 @@
+package com.gradle.develocity.agent.gradle.adapters.enterprise;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gradle.develocity.agent.gradle.adapters.BuildCacheConfigurationAdapter;
+import com.gradle.develocity.agent.gradle.adapters.develocity.GradleBuildCacheConfigurationAdapter;
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseBuildCache;
+
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class GradleEnterpriseBuildCacheConfigurationAdapterTest {
+
+    private GradleEnterpriseBuildCache cache;
+    private BuildCacheConfigurationAdapter.RemoteBuildCacheAdapter adapter;
+
+    @BeforeEach
+    void setup() {
+        cache = mock();
+        BuildCacheConfiguration configuration = mock(BuildCacheConfiguration.class);
+        when(configuration.getRemote()).thenReturn(cache);
+
+        adapter = new GradleBuildCacheConfigurationAdapter(configuration).getRemote();
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the server value using adapter")
+    void testServer() {
+        //given
+        String server = "https://ge-server.com";
+
+        // when
+        adapter.setServer(server);
+
+        // then
+        verify(cache).setServer(server);
+
+        // when
+        when(cache.getServer()).thenReturn(server);
+
+        // then
+        assertEquals(server, adapter.getServer());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the cache path using adapter")
+    void testPath() {
+        //given
+        String path = "path";
+
+        // when
+        adapter.setPath(path);
+
+        // then
+        verify(cache).setPath(path);
+
+        // when
+        when(cache.getPath()).thenReturn(path);
+
+        // then
+        assertEquals(path, adapter.getPath());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowUntrustedServer value using adapter")
+    void testAllowUntrustedServer() {
+        // when
+        adapter.setAllowUntrustedServer(true);
+
+        // then
+        verify(cache).setAllowUntrustedServer(true);
+
+        // when
+        when(cache.getAllowUntrustedServer()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowUntrustedServer());
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the allowInsecureProtocol value using adapter")
+    void testAllowInsecureProtocol() {
+        // when
+        adapter.setAllowInsecureProtocol(true);
+
+        // then
+        verify(cache).setAllowInsecureProtocol(true);
+
+        // when
+        when(cache.getAllowInsecureProtocol()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getAllowInsecureProtocol());
+    }
+
+    @Test
+    @DisplayName("can set the username and password value using adapter")
+    void testUsernameAndPassword() {
+        // given
+        String username = "user";
+        String password = "pass";
+
+        // when
+        adapter.usernameAndPassword(username, password);
+
+        // then
+        verify(cache).usernameAndPassword(username, password);
+    }
+
+    @Test
+    @DisplayName("can set and retrieve the useExpectContinue value using adapter")
+    void testUseExpectContinue() {
+        // when
+        adapter.setUseExpectContinue(true);
+
+        // then
+        verify(cache).setUseExpectContinue(true);
+
+        // when
+        when(cache.getUseExpectContinue()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.getUseExpectContinue());
+    }
+
+    @Test
+    @DisplayName("can enable using adapter")
+    void testEnable() {
+        // when
+        adapter.setEnabled(true);
+
+        // then
+        verify(cache).setEnabled(true);
+
+        // when
+        when(cache.isEnabled()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isEnabled());
+    }
+
+    @Test
+    @DisplayName("can enable pushing using adapter")
+    void testPush() {
+        // when
+        adapter.setPush(true);
+
+        // then
+        verify(cache).setPush(true);
+
+        // when
+        when(cache.isPush()).thenReturn(true);
+
+        // then
+        assertTrue(adapter.isPush());
+    }
+}

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/GradleEnterpriseExtensionAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/GradleEnterpriseExtensionAdapterTest.java
@@ -2,6 +2,7 @@ package com.gradle.develocity.agent.gradle.adapters.enterprise;
 
 import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter;
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
+import com.gradle.enterprise.gradleplugin.internal.extension.GradleEnterpriseExtensionWithHiddenFeatures;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -41,6 +43,19 @@ class GradleEnterpriseExtensionAdapterTest {
 
         // then
         assertTrue(e.getMessage().contains("is not a Gradle Enterprise extension"));
+    }
+
+    @Test
+    @DisplayName("can unwrap deeply nested Gradle Enterprise extension")
+    void testNestedExtension() {
+        // when
+        GradleEnterpriseExtension nestedExtension = mock(DeeplyNestedGradleEnterpriseExtensionWrapper.class);
+        when(nestedExtension.getBuildScan()).thenReturn(buildScan);
+
+        GradleEnterpriseExtensionAdapter adapter = new GradleEnterpriseExtensionAdapter(nestedExtension);
+
+        // then
+        assertNotNull(adapter);
     }
 
     @Test
@@ -140,4 +155,7 @@ class GradleEnterpriseExtensionAdapterTest {
         verify(buildScan).setTermsOfServiceUrl("server");
     }
 
+    interface GradleEnterpriseExtensionWrapper extends GradleEnterpriseExtension {}
+    interface NestedGradleEnterpriseExtensionWrapper extends GradleEnterpriseExtensionWrapper {}
+    interface DeeplyNestedGradleEnterpriseExtensionWrapper extends NestedGradleEnterpriseExtensionWrapper {}
 }


### PR DESCRIPTION
With these changes, the `develocity-agent-adapters` library will function with a wider range of `com.gradle.develocity`, `com.gradle.enterprise` and `com.gradle.build-scan` plugin versions.

Specific issues that were addressed:
- gradle/develocity-agent-adapters#94
- gradle/develocity-agent-adapters#95
- gradle/develocity-agent-adapters#96

When combined with https://github.com/bigdaz/common-custom-user-data-gradle-plugin/commit/162c0b41cd1edf23190228f95bb8b9fc73d1148e, these improvements will result in a CCUD plugin that is compatible with GradleEnterprise/BuildScan plugins back to versions `1.15` and `3.0`.

As a follow up to these changes, we should probably remove the old `BuildCacheAdapter` API and implementations. These have been replaced by `BuildCacheConfigurationAdapter.RemoteBuildCacheAdapter`.